### PR TITLE
add srcObject for getUserMedia

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -147,6 +147,7 @@ var HTMLDOMPropertyConfig = {
     srcDoc: 0,
     srcLang: 0,
     srcSet: 0,
+    srcObject: 0,
     start: HAS_NUMERIC_VALUE,
     step: 0,
     style: 0,


### PR DESCRIPTION
srcObject is useful when use `video` elements in webRTC video chat.
`video.srcObject = stream` is standard and well-implemented. 
you can use `video.src=URL.createObjectURL(stream)` or `video.src=stream.toURL()`.
but it's a hack and deprecated. don't use it.

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`).
6. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
7. If you added or removed any tests, run `./scripts/fiber/record-tests` before submitting the pull request, and commit the resulting changes.
8. If you haven't already, complete the [CLA](https://code.facebook.com/cla).
